### PR TITLE
BC Intorduced in one of last commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,17 @@ cache:
     directories:
         - $HOME/.composer/cache
 
+matrix:
+    include:
+        - php: 7.2
+          env:
+              - DB=mysql
+              - SYMFONY_REQUIRE="^4"
+        - php: 7.2
+          env:
+              - DB=mysql
+              - SYMFONY_REQUIRE="^3.4"
+
 php:
     - 7.2
     - 7.3
@@ -26,6 +37,7 @@ before_install:
     - composer self-update
 
 install:
+    - if [ "$SYMFONY_REQUIRE" != "" ]; then composer global require --no-progress --no-scripts --no-plugins symfony/flex; fi;
     - COMPOSER_MEMORY_LIMIT=-1 composer update $COMPOSER_FLAGS --prefer-dist
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "phpstan/phpstan-strict-rules": "^0.12",
     "phpstan/phpstan-symfony": "^0.12",
     "phpunit/phpunit": "^7.0|^8.0",
-    "symfony/var-dumper": "^4.2|^5.0",
+    "symfony/var-dumper": "^3.4|^4.2|^5.0",
     "twig/extensions": "^1.5"
   },
   "conflict": {

--- a/tests/DoctrineAuditBundle/Routing/RoutingAnnotationLoaderTest.php
+++ b/tests/DoctrineAuditBundle/Routing/RoutingAnnotationLoaderTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Tests\Routing;
+
+use DH\DoctrineAuditBundle\Routing\RoutingAnnotationLoader;
+use DH\DoctrineAuditBundle\Tests\CoreTest;
+use Symfony\Bundle\FrameworkBundle\Routing\AnnotatedRouteControllerLoader;
+
+class RoutingAnnotationLoaderTest extends CoreTest
+{
+    public function testSupportsReturnsTrue()
+    {
+        $annotatedRouteController = $this->prophesize(AnnotatedRouteControllerLoader::class);
+        $routingAnnotationLoader = new RoutingAnnotationLoader($annotatedRouteController->reveal(), []);
+
+        $result = $routingAnnotationLoader->supports(null, 'audit');
+
+        $this->assertTrue($result);
+    }
+}


### PR DESCRIPTION
After last refactors it has been introduced a break compatibility with `symfony/config` < 5.x .

I've updated travis file to lock sf version dependencies, with symfony-flex, to be compliant together in a test running.

This PR is only a Failure test. We could discuss about a solution.