### PR TITLE
Add Reader Conditions

### DIFF
--- a/src/DoctrineAuditBundle/Reader/AuditReader.php
+++ b/src/DoctrineAuditBundle/Reader/AuditReader.php
@@ -490,11 +490,8 @@ class AuditReader
             ;
         }
 
-        $this->filterByObjectId($queryBuilder, $id);
-        $this->filterByType($queryBuilder, $this->filters);
-        $this->filterByTransaction($queryBuilder, $transactionHash);
-        $this->filterByDate($queryBuilder, $startDate, $endDate);
-        $this->filterByConditions($queryBuilder);
+        $this->applyArgumentFilters($queryBuilder, $id, $transactionHash, $startDate, $endDate);
+        $this->applyConditions($queryBuilder);
 
         if (null !== $pageSize) {
             $queryBuilder
@@ -567,10 +564,38 @@ class AuditReader
         throw new AccessDeniedException('You are not allowed to access audits of '.$entity.' entity.');
     }
 
-    private function filterByConditions(QueryBuilder $queryBuilder)
+    private function applyConditions(QueryBuilder $queryBuilder)
     {
         foreach ($this->conditions as $condition) {
             $condition->apply($queryBuilder);
+        }
+    }
+
+    /**
+     * @param QueryBuilder $queryBuilder
+     * @param $id
+     * @param string|null $transactionHash
+     * @param DateTime|null $startDate
+     * @param DateTime|null $endDate
+     */
+    private function applyArgumentFilters(
+        QueryBuilder $queryBuilder,
+        $id,
+        ?string $transactionHash,
+        ?DateTime $startDate,
+        ?DateTime $endDate
+    ): void {
+        if (isset($id)) {
+            $this->filterByObjectId($queryBuilder, $id);
+        }
+        if (isset($this->filters)) {
+            $this->filterByType($queryBuilder, $this->filters);
+        }
+        if (isset($transactionHash)) {
+            $this->filterByTransaction($queryBuilder, $transactionHash);
+        }
+        if (isset($startDate) && isset($endDate)) {
+            $this->filterByDate($queryBuilder, $startDate, $endDate);
         }
     }
 }

--- a/src/DoctrineAuditBundle/Reader/ConditionInterface.php
+++ b/src/DoctrineAuditBundle/Reader/ConditionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Reader;
+
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+interface ConditionInterface
+{
+    public function apply(QueryBuilder $queryBuilder);
+}

--- a/src/DoctrineAuditBundle/Reader/ConditionInterface.php
+++ b/src/DoctrineAuditBundle/Reader/ConditionInterface.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace DH\DoctrineAuditBundle\Reader;
-
 
 use Doctrine\DBAL\Query\QueryBuilder;
 

--- a/src/DoctrineAuditBundle/Reader/DateRangeCondition.php
+++ b/src/DoctrineAuditBundle/Reader/DateRangeCondition.php
@@ -1,0 +1,54 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Reader;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class DateRangeCondition implements ConditionInterface
+{
+    /**
+     * @var \DateTime|null
+     */
+    private $startDate;
+
+    /**
+     * @var \DateTime|null
+     */
+    private $endDate;
+
+    /**
+     * Apply date filtering.
+     *
+     * @param \DateTime|null $startDate
+     * @param \DateTime|null $endDate
+     */
+    public function __construct(?\DateTime $startDate, ?\DateTime $endDate)
+    {
+        $this->startDate = $startDate;
+        $this->endDate   = $endDate;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        if (null !== $this->startDate && null !== $this->endDate && $this->endDate < $this->startDate) {
+            throw new \InvalidArgumentException('End date must be greater than start date.');
+        }
+
+        if (null !== $this->startDate) {
+            $queryBuilder
+                ->andWhere('created_at >= :start_date')
+                ->setParameter('start_date', $this->startDate->format('Y-m-d H:i:s'))
+            ;
+        }
+
+        if (null !== $this->endDate) {
+            $queryBuilder
+                ->andWhere('created_at <= :end_date')
+                ->setParameter('end_date', $this->endDate->format('Y-m-d H:i:s'))
+            ;
+        }
+    }
+}

--- a/src/DoctrineAuditBundle/Reader/DateRangeCondition.php
+++ b/src/DoctrineAuditBundle/Reader/DateRangeCondition.php
@@ -4,7 +4,6 @@
 namespace DH\DoctrineAuditBundle\Reader;
 
 
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 
 class DateRangeCondition implements ConditionInterface

--- a/src/DoctrineAuditBundle/Reader/ObjectIdCondition.php
+++ b/src/DoctrineAuditBundle/Reader/ObjectIdCondition.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Reader;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class ObjectIdCondition implements ConditionInterface
+{
+    /**
+     * @var null|int|string
+     */
+    private $id;
+
+    /**
+     * Apply object id filtering
+     *
+     * @param null|int|string $id
+     */
+    public function __construct($id = null)
+    {
+        $this->id = $id;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        if (null !== $this->id) {
+            $queryBuilder
+                ->andWhere('object_id = :object_id')
+                ->setParameter('object_id', $this->id)
+            ;
+        }
+    }
+}

--- a/src/DoctrineAuditBundle/Reader/ObjectIdCondition.php
+++ b/src/DoctrineAuditBundle/Reader/ObjectIdCondition.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace DH\DoctrineAuditBundle\Reader;
 
-
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 
 class ObjectIdCondition implements ConditionInterface

--- a/src/DoctrineAuditBundle/Reader/TransactionCondition.php
+++ b/src/DoctrineAuditBundle/Reader/TransactionCondition.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Reader;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class TransactionCondition implements ConditionInterface
+{
+    /**
+     * @var string
+     */
+    private $transactionHash;
+
+    /**
+     * Apply transaction filtering
+     *
+     * @param array $types
+     */
+    public function __construct($transactionHash)
+    {
+        $this->transactionHash = $transactionHash;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        if (null !== $this->transactionHash) {
+            $queryBuilder
+                ->andWhere('transaction_hash = :transaction_hash')
+                ->setParameter('transaction_hash', $this->transactionHash)
+            ;
+        }
+    }
+}

--- a/src/DoctrineAuditBundle/Reader/TransactionCondition.php
+++ b/src/DoctrineAuditBundle/Reader/TransactionCondition.php
@@ -1,10 +1,7 @@
 <?php
 
-
 namespace DH\DoctrineAuditBundle\Reader;
 
-
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;
 
 class TransactionCondition implements ConditionInterface

--- a/src/DoctrineAuditBundle/Reader/TypesCondition.php
+++ b/src/DoctrineAuditBundle/Reader/TypesCondition.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Reader;
+
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class TypesCondition implements ConditionInterface
+{
+    /**
+     * @var array
+     */
+    private $types;
+
+    /**
+     * Apply types filtering
+     *
+     * @param array $types
+     */
+    public function __construct($types)
+    {
+        $this->types = $types;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        if (!empty($this->types)) {
+            $queryBuilder
+                ->andWhere('type IN (:filters)')
+                ->setParameter('filters', $this->types, Connection::PARAM_STR_ARRAY)
+            ;
+        }
+    }
+}

--- a/src/DoctrineAuditBundle/Reader/TypesCondition.php
+++ b/src/DoctrineAuditBundle/Reader/TypesCondition.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace DH\DoctrineAuditBundle\Reader;
-
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Query\QueryBuilder;

--- a/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
+++ b/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace DH\DoctrineAuditBundle\Tests\Reader;
+
+use DateTime;
+use DH\DoctrineAuditBundle\Configuration;
+use DH\DoctrineAuditBundle\Model\Entry;
+use DH\DoctrineAuditBundle\Reader\Reader;
+use DH\DoctrineAuditBundle\Tests\CoreTest;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Annotation\AuditedEntity;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Annotation\UnauditedEntity;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Author;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post;
+use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Tag;
+use InvalidArgumentException;
+
+/**
+ * @internal
+ */
+final class CustomConditionTest extends CoreTest
+{
+    public function testAddCustomCondition(): void
+    {
+        $reader = $this->getReader($this->getAuditConfiguration());
+        $reader->addCondition(new NotOfTypeCondition(Reader::REMOVE));
+
+        /** @var Entry[] $audits */
+        $audits = $reader->getAudits(Author::class, null, 1, 50);
+
+        $i = 0;
+        self::assertCount(4, $audits, 'result count is ok.');
+        self::assertSame(Reader::UPDATE, $audits[$i++]->getType(), 'entry'.$i.' is an update operation.');
+        self::assertSame(Reader::INSERT, $audits[$i++]->getType(), 'entry'.$i.' is an insert operation.');
+        self::assertSame(Reader::INSERT, $audits[$i++]->getType(), 'entry'.$i.' is an insert operation.');
+        self::assertSame(Reader::INSERT, $audits[$i++]->getType(), 'entry'.$i.' is an insert operation.');
+    }
+}

--- a/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
+++ b/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
@@ -4,7 +4,7 @@ namespace DH\DoctrineAuditBundle\Tests\Reader;
 
 use DH\DoctrineAuditBundle\Configuration;
 use DH\DoctrineAuditBundle\Model\Entry;
-use DH\DoctrineAuditBundle\Reader\Reader;
+use DH\DoctrineAuditBundle\Reader\AuditReader as Reader;
 use DH\DoctrineAuditBundle\Tests\CoreTest;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Author;
 

--- a/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
+++ b/tests/DoctrineAuditBundle/Reader/CustomConditionTest.php
@@ -2,18 +2,11 @@
 
 namespace DH\DoctrineAuditBundle\Tests\Reader;
 
-use DateTime;
 use DH\DoctrineAuditBundle\Configuration;
 use DH\DoctrineAuditBundle\Model\Entry;
 use DH\DoctrineAuditBundle\Reader\Reader;
 use DH\DoctrineAuditBundle\Tests\CoreTest;
-use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Annotation\AuditedEntity;
-use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Annotation\UnauditedEntity;
 use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Author;
-use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Comment;
-use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Post;
-use DH\DoctrineAuditBundle\Tests\Fixtures\Core\Standard\Tag;
-use InvalidArgumentException;
 
 /**
  * @internal

--- a/tests/DoctrineAuditBundle/Reader/NotOfTypeCondition.php
+++ b/tests/DoctrineAuditBundle/Reader/NotOfTypeCondition.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace DH\DoctrineAuditBundle\Tests\Reader;
+
+
+use DH\DoctrineAuditBundle\Reader\ConditionInterface;
+use Doctrine\DBAL\Query\QueryBuilder;
+
+class NotOfTypeCondition implements ConditionInterface
+{
+    private $type;
+
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    public function apply(QueryBuilder $queryBuilder)
+    {
+        if (!empty($this->type)) {
+            $queryBuilder
+                ->andWhere('type <> :type')
+                ->setParameter('type', $this->type)
+            ;
+        }
+    }
+}


### PR DESCRIPTION
Add ways to set reader conditions.
For now just simply add conditions for all existing internal filterBy* calls and allow to add own conditions.
To-do: make the original conditions apply by default (to keep BC, but allow to remove all default conditions and just add your own or just a few provided).

Also see https://github.com/DamienHarper/DoctrineAuditBundle/issues/164