### PR TITLE
Add branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,5 +60,10 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "4.0-dev"
+        }
     }
 }


### PR DESCRIPTION
This allows for version restricted installs such as `4.0.x-dev || ^4.0`.