### PR TITLE
Handle TableNotFoundException.

### DIFF
--- a/src/DoctrineAuditBundle/Event/AuditSubscriber.php
+++ b/src/DoctrineAuditBundle/Event/AuditSubscriber.php
@@ -3,6 +3,7 @@
 namespace DH\DoctrineAuditBundle\Event;
 
 use DH\DoctrineAuditBundle\Manager\AuditManager;
+use Doctrine\DBAL\Exception\TableNotFoundException;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class AuditSubscriber implements EventSubscriberInterface
@@ -61,11 +62,18 @@ class AuditSubscriber implements EventSubscriberInterface
         $storage = $this->manager->selectStorageSpace($this->manager->getConfiguration()->getEntityManager());
         $statement = $storage->getConnection()->prepare($query);
 
-        foreach ($payload as $key => $value) {
+        foreach ($payload as $key => $value)
+        {
             $statement->bindValue($key, $value);
         }
 
-        $statement->execute();
+        try
+        {
+            $statement->execute();
+        }
+        catch (TableNotFoundException $e)
+        {
+        }
 
         return $event;
     }


### PR DESCRIPTION
Allows to  use bundle prior to having any *_audit table created. Solved https://github.com/DamienHarper/auditor-bundle/issues/204