### PR TITLE
Bug in the pager that makes the pagination pages unreachable

### DIFF
--- a/src/Resources/views/Audit/entity_history.html.twig
+++ b/src/Resources/views/Audit/entity_history.html.twig
@@ -26,7 +26,7 @@
         {% endfor %}
         </div>
 
-        {{ pager.render(entity, id, paginator) }}
+        {{ pager.render(helper.namespaceToParam(entity), id, paginator) }}
     </div>
 </div>
 {% endblock dh_auditor_content %}


### PR DESCRIPTION
Bug in pagination, the pager prints the routes like 
http://my-domain.com/my-project/public/audit/App/Entity/User?page=7
instead
http://my-domain.com/my-project/public/audit/App-Entity-User?page=7