### PR TITLE
Remove the ROLE_PREVIOUS_ADMIN deprecation warning from Symfony 5.1

### DIFF
--- a/src/DoctrineAuditBundle/User/TokenStorageUserProvider.php
+++ b/src/DoctrineAuditBundle/User/TokenStorageUserProvider.php
@@ -38,7 +38,12 @@ class TokenStorageUserProvider implements UserProviderInterface
         }
 
         $impersonation = '';
-        if ($this->security->isGranted('ROLE_PREVIOUS_ADMIN')) {
+        // The ROLE_PREVIOUS_ADMIN role is deprecated since Symfony 5.1 and will be removed in version 6.0.
+        $impersonationAttribute
+            = \defined('\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::IS_IMPERSONATOR')
+            ? 'IS_IMPERSONATOR'
+            : 'ROLE_PREVIOUS_ADMIN';
+        if ($this->security->isGranted($impersonationAttribute)) {
             // Symfony > 4.3
             if ($token instanceof SwitchUserToken) {
                 $impersonatorUser = $token->getOriginalToken()->getUser();

--- a/tests/DoctrineAuditBundle/CoreTest.php
+++ b/tests/DoctrineAuditBundle/CoreTest.php
@@ -232,11 +232,16 @@ abstract class CoreTest extends BaseTest
         $user->setRoles(['ROLE_ADMIN']);
         $tokenStorage->setToken(new UsernamePasswordToken($user, '12345', 'provider', $user->getRoles()));
 
+        // The ROLE_PREVIOUS_ADMIN role is deprecated since Symfony 5.1 and will be removed in version 6.0.
+        $impersonationAttribute
+            = \defined('\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::IS_IMPERSONATOR')
+            ? 'IS_IMPERSONATOR'
+            : 'ROLE_PREVIOUS_ADMIN';
         $authorizationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
         $authorizationChecker
             ->expects(static::any())
             ->method('isGranted')
-            ->with('ROLE_PREVIOUS_ADMIN')
+            ->with($impersonationAttribute)
             ->willReturn(true)
         ;
 

--- a/tests/DoctrineAuditBundle/User/TokenStorageUserProviderTest.php
+++ b/tests/DoctrineAuditBundle/User/TokenStorageUserProviderTest.php
@@ -23,12 +23,18 @@ final class TokenStorageUserProviderTest extends TestCase
 
     protected function setUp(): void
     {
+        // The ROLE_PREVIOUS_ADMIN role is deprecated since 5.1 and will be removed in version 6.0.
+        $impersonationAttribute
+            = \defined('\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::IS_IMPERSONATOR')
+            ? 'IS_IMPERSONATOR'
+            : 'ROLE_PREVIOUS_ADMIN';
+
         $this->tokenStorage = new TokenStorage();
         $this->authorizationChecker = $this->getMockBuilder(AuthorizationCheckerInterface::class)->getMock();
         $this->authorizationChecker
             ->expects(self::any())
             ->method('isGranted')
-            ->with('ROLE_PREVIOUS_ADMIN')
+            ->with($impersonationAttribute)
             ->willReturn(true)
         ;
     }
@@ -57,7 +63,12 @@ final class TokenStorageUserProviderTest extends TestCase
         if (class_exists('\Symfony\Component\Security\Core\Authentication\Token\SwitchUserToken')) {
             $token2 = new SwitchUserToken($user2, '12345', 'provider', $user2->getRoles(), $token1);
         } else {
-            $user2->setRoles(['ROLE_USER', 'ROLE_PREVIOUS_ADMIN', new SwitchUserRole('ROLE_ADMIN', $token1)]);
+            // The ROLE_PREVIOUS_ADMIN role is deprecated since Symfony 5.1 and will be removed in version 6.0.
+            $impersonationAttribute
+                = \defined('\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::IS_IMPERSONATOR')
+                ? 'IS_IMPERSONATOR'
+                : 'ROLE_PREVIOUS_ADMIN';
+            $user2->setRoles(['ROLE_USER', $impersonationAttribute, new SwitchUserRole('ROLE_ADMIN', $token1)]);
             $token2 = new UsernamePasswordToken($user2, '12345', 'provider', $user2->getRoles());
         }
 


### PR DESCRIPTION
Since `symfony/security-core 5.1` `ROLE_PREVIOUS_ADMIN` is deprecated and should change to IS_IMPERSONATOR instead.

I created a check for the current constant of it: `'\Symfony\Component\Security\Core\Authorization\Voter\AuthenticatedVoter::IS_IMPERSONATOR` and change the impersonating attribute accordingly.

I applied the same logic to tests

Fixes #206 
