### PR TITLE
Update Configuration comment as viewer is now disabled by default

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -105,7 +105,7 @@ class Configuration implements ConfigurationInterface
                         $v['doctrine']['auditing_services'] = ['doctrine.orm.default_entity_manager'];
                     }
 
-                    // "viewer" is enabled by default
+                    // "viewer" is disabled by default
                     if (!\array_key_exists('viewer', $v['doctrine']) || !\is_bool($v['doctrine']['viewer'])) {
                         $v['doctrine']['viewer'] = false;
                     }


### PR DESCRIPTION
followup to https://github.com/DamienHarper/auditor-bundle/commit/a155712f7dbbf73f9c74c52ba6b1a665215abd3a that changed the behaviour but not the comment