### PR TITLE
Prevent deprecation notice when using Symfony 5.4.2

### DIFF
--- a/src/Event/ViewerEventSubscriber.php
+++ b/src/Event/ViewerEventSubscriber.php
@@ -52,7 +52,7 @@ class ViewerEventSubscriber implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::CONTROLLER => 'onKernelController',


### PR DESCRIPTION
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "DH\AuditorBundle\Event\ViewerEventSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message.