### PR TITLE
Cast to string the user identifier

### DIFF
--- a/src/User/UserProvider.php
+++ b/src/User/UserProvider.php
@@ -60,7 +60,7 @@ class UserProvider implements UserProviderInterface
             return null;
         }
 
-        return new User($identifier, $username);
+        return new User((string)$identifier, $username);
     }
 
     private function getTokenUser(): ?UserInterface

--- a/src/User/UserProvider.php
+++ b/src/User/UserProvider.php
@@ -60,7 +60,7 @@ class UserProvider implements UserProviderInterface
             return null;
         }
 
-        return new User((string)$identifier, $username);
+        return new User((string) $identifier, $username);
     }
 
     private function getTokenUser(): ?UserInterface


### PR DESCRIPTION
Since the DH\Auditor\User\User constructor requires the first argument to be string or null. I have an UserInterface implementation where $tokenUser->getId() returns int, so there will be an exception. The check is on DH\AuditorBundle\User\UserProvider: if (method_exists($tokenUser, 'getId')) { $identifier = $tokenUser->getId(); }. To be safe, it is better to cast the getId() value to string, IMHO.