### PR TITLE
Missing German translations

### DIFF
--- a/src/translations/auditor.de.yaml
+++ b/src/translations/auditor.de.yaml
@@ -1,7 +1,7 @@
 audit:
   header:
     home: Home
-    audited_entities: audited entities
+    audited_entities: auditierte Objekte
   audit_details:
     view_audit: Audits anzeigen
     most_recent: (neueste zuerst)
@@ -11,7 +11,7 @@ audit:
     new_value: Neuer Wert
     transaction: Transaktion
     entity_per_entity: (Objekt pro Objekt)
-    operations_count: '%count% operation(s)'
+    operations_count: '%count% Operation(en)'
     summary:
       inserted: >-
         <code class="text-pink-500">


### PR DESCRIPTION
Hi,

I really love auditor-bundle. 
I just noticed missing translations for German.

I think everyone understands "Home". But "operations" should be "Operationen" :-D