### PR TITLE
title, navbar and breadcrums in block tags

### DIFF
--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -45,7 +45,7 @@
     </nav>
     {% endblock %}
 
-    {% block breadcrums %}
+    {% block breadcrumbs %}
     <header class="bg-white">
         <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
             {% block dh_auditor_header %}{% endblock %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -38,16 +38,6 @@
                             </svg>
                         </a>
                     </div>
-{#                    <div class="hidden md:block">#}
-{#                        <div class="ml-10 flex items-baseline space-x-4">#}
-{#                            <!-- Current: "bg-gray-900 text-white", Default: "text-gray-300 hover:bg-gray-700 hover:text-white" -->#}
-{#                            <a href="#" class="bg-gray-900 text-white px-3 py-2 rounded-md text-sm font-medium" aria-current="page">Dashboard</a>#}
-{#                            <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Team</a>#}
-{#                            <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Projects</a>#}
-{#                            <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Calendar</a>#}
-{#                            <a href="#" class="text-gray-300 hover:bg-gray-700 hover:text-white px-3 py-2 rounded-md text-sm font-medium">Reports</a>#}
-{#                        </div>#}
-{#                    </div>#}
                 </div>
             </div>
         </div>
@@ -55,9 +45,7 @@
 
     <header class="bg-white">
         <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
-{#            <h1 class="text-lg leading-6 font-semibold text-gray-900">#}
             {% block dh_auditor_header %}{% endblock %}
-{#            </h1>#}
         </div>
     </header>
     <main>

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="{{ app.request.locale }}">
 <head>
     <meta charset="UTF-8" />
     <title>auditor</title>

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -2,7 +2,7 @@
 <html lang="{{ app.request.locale }}">
 <head>
     <meta charset="UTF-8" />
-    <title>auditor</title>
+    <title>{% block title %}auditor{% endblock %}</title>
     {% block stylesheets %}
         <link rel="stylesheet" href="{{ asset('bundles/dhauditor/app.css') }}">
     {% endblock %}

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,5 +1,4 @@
 <!DOCTYPE html>
-<html lang="en">
 <head>
     <meta charset="UTF-8" />
     <title>auditor</title>

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <meta charset="UTF-8" />
     <title>auditor</title>
@@ -9,6 +9,7 @@
 </head>
 <body>
 <div>
+    {% block navbar %}
     <nav class="bg-gray-800">
         <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div class="flex items-center justify-between h-16">
@@ -42,12 +43,16 @@
             </div>
         </div>
     </nav>
+    {% endblock %}
 
+    {% block breadcrums %}
     <header class="bg-white">
         <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8">
             {% block dh_auditor_header %}{% endblock %}
         </div>
     </header>
+    {% endblock %}
+
     <main>
         <div class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
             {% block dh_auditor_content %}{% endblock %}


### PR DESCRIPTION
Wrapped the title, navbar and the breadcrums in blocks so you could override them without having to override the whole file. Also removed some unused code and added the current locale to the language attribute of the html-element. 