### PR TITLE
Fix: `ViewerController`

### DIFF
--- a/.github/workflows/ci-4.x.yml
+++ b/.github/workflows/ci-4.x.yml
@@ -29,9 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: 4.x
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci-5.x.yml
+++ b/.github/workflows/ci-5.x.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: 5.x
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -57,9 +55,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: 5.x
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -130,9 +126,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: 5.x
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -65,7 +65,7 @@ class ViewerController
      */
     public function showTransactionAction(Reader $reader, string $hash): Response
     {
-        $audits = $reader->getAuditsByTransactionHash($hash);
+        $audits = []; $reader->getAuditsByTransactionHash($hash);
 
         return $this->renderView('@DHAuditor/Audit/transaction.html.twig', [
             'hash' => $hash,

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -10,6 +10,7 @@ use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\AuditorBundle\Helper\UrlHelper;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -17,7 +18,7 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest
  */
-class ViewerController
+class ViewerController extends AbstractController
 {
     private $environment;
 

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -12,6 +12,7 @@ use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\AuditorBundle\Helper\UrlHelper;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Twig\Environment;
 
@@ -85,7 +86,7 @@ class ViewerController
         $entity = UrlHelper::paramToNamespace($entity);
 
         if (!$reader->getProvider()->isAuditable($entity)) {
-            throw $this->createNotFoundException();
+            throw new NotFoundHttpException('Not Found');
         }
 
         try {
@@ -95,7 +96,7 @@ class ViewerController
                 'page_size' => Reader::PAGE_SIZE,
             ]), $page, Reader::PAGE_SIZE);
         } catch (AccessDeniedException $e) {
-            throw $this->createAccessDeniedException();
+            throw new \Symfony\Component\Security\Core\Exception\AccessDeniedException('Access Denied.');
         }
 
         return $this->renderView('@DHAuditor/Audit/entity_history.html.twig', [
@@ -107,6 +108,6 @@ class ViewerController
 
     protected function renderView(string $view, array $parameters = []): Response
     {
-        return new Response ($this->environment->render($view, $parameters));
+        return new Response($this->environment->render($view, $parameters));
     }
 }

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -14,8 +14,8 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
-use Twig\Environment;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException as SymfonyAccessDeniedException;
+use Twig\Environment;
 
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -15,6 +15,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Twig\Environment;
+use Symfony\Component\Security\Core\Exception\AccessDeniedException as SymfonyAccessDeniedException;
 
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest
@@ -96,7 +97,7 @@ class ViewerController
                 'page_size' => Reader::PAGE_SIZE,
             ]), $page, Reader::PAGE_SIZE);
         } catch (AccessDeniedException $e) {
-            throw new \Symfony\Component\Security\Core\Exception\AccessDeniedException('Access Denied.');
+            throw new SymfonyAccessDeniedException('Access Denied.');
         }
 
         return $this->renderView('@DHAuditor/Audit/entity_history.html.twig', [

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -14,6 +14,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
 
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest
@@ -22,7 +23,7 @@ class ViewerController extends AbstractController
 {
     private $environment;
 
-    public function __construct(\Twig\Environment $environment)
+    public function __construct(Environment $environment)
     {
         $this->environment = $environment;
     }

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -10,7 +10,6 @@ use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\AuditorBundle\Helper\UrlHelper;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -18,7 +17,7 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest
  */
-class ViewerController extends AbstractController
+class ViewerController
 {
     private $environment;
 
@@ -53,7 +52,7 @@ class ViewerController extends AbstractController
             );
         }
 
-        return $this->render('@DHAuditor/Audit/audits.html.twig', [
+        return $this->renderView('@DHAuditor/Audit/audits.html.twig', [
             'audited' => $audited,
             'reader' => $reader,
         ]);
@@ -66,7 +65,7 @@ class ViewerController extends AbstractController
     {
         $audits = $reader->getAuditsByTransactionHash($hash);
 
-        return $this->render('@DHAuditor/Audit/transaction.html.twig', [
+        return $this->renderView('@DHAuditor/Audit/transaction.html.twig', [
             'hash' => $hash,
             'audits' => $audits,
         ]);
@@ -98,15 +97,15 @@ class ViewerController extends AbstractController
             throw $this->createAccessDeniedException();
         }
 
-        return $this->render('@DHAuditor/Audit/entity_history.html.twig', [
+        return $this->renderView('@DHAuditor/Audit/entity_history.html.twig', [
             'id' => $id,
             'entity' => $entity,
             'paginator' => $pager,
         ]);
     }
 
-    protected function renderView(string $view, array $parameters = []): string
+    protected function renderView(string $view, array $parameters = []): Response
     {
-        return $this->environment->render($view, $parameters);
+        return new Response ($this->environment->render($view, $parameters));
     }
 }

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -10,7 +10,6 @@ use DH\Auditor\Provider\Doctrine\Persistence\Reader\Reader;
 use DH\Auditor\Provider\Doctrine\Persistence\Schema\SchemaManager;
 use DH\Auditor\Provider\Doctrine\Service\AuditingService;
 use DH\AuditorBundle\Helper\UrlHelper;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
@@ -19,7 +18,7 @@ use Twig\Environment;
 /**
  * @see \DH\AuditorBundle\Tests\Controller\ViewerControllerTest
  */
-class ViewerController extends AbstractController
+class ViewerController
 {
     private $environment;
 

--- a/src/Controller/ViewerController.php
+++ b/src/Controller/ViewerController.php
@@ -66,7 +66,7 @@ class ViewerController
      */
     public function showTransactionAction(Reader $reader, string $hash): Response
     {
-        $audits = []; $reader->getAuditsByTransactionHash($hash);
+        $audits = $reader->getAuditsByTransactionHash($hash);
 
         return $this->renderView('@DHAuditor/Audit/transaction.html.twig', [
             'hash' => $hash,

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -67,8 +67,6 @@ services:
   # Bundle related services
   DH\AuditorBundle\Controller\ViewerController:
     arguments: ['@twig']
-    calls:
-      - { method: setContainer, arguments: ['@service_container'] }
     tags: ['controller.service_arguments']
 
   DH\AuditorBundle\User\UserProvider:


### PR DESCRIPTION
After upgrading to Symfony 6.4, the ViewerController stopped working while throwing the following exception:

```
Uncaught PHP Exception LogicException: "You cannot use the "render" method if the Twig Bundle is not available. Try running "composer require symfony/twig-bundle"." at AbstractController.php line 435
```

Upon investigation with @mvhirsch, we discovered that the service_container injected into the controller lacked the twig service. However, this shouldn't have been a problem since twig was injected directly via arguments. The root cause turned out to be the use of `AbstractController::render()` method, which attempts to access twig from the service container, instead of the intended `ViewerController::renderView()`.

Additionally, I've realized that there is no necessity to inject the service_container or extend the `AbstractController`. We’re currently running tests to see if this resolves the issue.

Thank you for your assistance and insights