### PR TITLE
Useless `ext-json` requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,6 @@
     ],
     "require": {
         "php": ">=8.2",
-        "ext-json": "*",
         "damienharper/auditor": "dev-master",
         "doctrine/doctrine-bundle": "^2.0",
         "doctrine/orm": "^2.13",


### PR DESCRIPTION
Remove useless `ext-json` requirement from `composer.json` 
@see https://php.watch/versions/8.0/ext-json