### PR TITLE
Fix Twig spaceless filter deprecation

### DIFF
--- a/src/Resources/views/Audit/helpers/helper.html.twig
+++ b/src/Resources/views/Audit/helpers/helper.html.twig
@@ -1,20 +1,18 @@
 {% macro dump(value, separator) %}
-    {% import _self as helper %}
-    {% apply spaceless %}
-        {% if value.label is defined %}
-            {{ value.label }}
-        {% elseif value is iterable %}
-            {% for k, v in value %}
-                {{ k }}: {{ helper.dump(v) }}{{ separator|default('<br/>')|raw }}
-            {% endfor %}
-        {% elseif value is same as(true) %}
-            {{ 'true' }}
-        {% elseif value is same as(false) %}
-            {{ 'false' }}
-        {% else %}
-            {{ value }}
-        {% endif %}
-    {% endapply %}
+    {%- import _self as helper -%}
+    {%- if value.label is defined -%}
+        {{- value.label -}}
+    {%- elseif value is iterable -%}
+        {%- for k, v in value -%}
+            {{- k }}: {{ helper.dump(v) }}{{ separator|default('<br/>')|raw -}}
+        {%- endfor -%}
+    {%- elseif value is same as(true) -%}
+        true
+    {%- elseif value is same as(false) -%}
+        false
+    {%- else -%}
+        {{- value -}}
+    {%- endif -%}
 {% endmacro dump %}
 
 {% macro namespaceToParam(entity) %}
@@ -77,38 +75,33 @@
 
 
 {% macro icon_type(value) %}
-    {% apply spaceless %}
-        {% if value == 'insert' %}
-            {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" /></svg>' }}
-        {% elseif value == 'update' %}
-            {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" /></svg>' }}
-        {% elseif value == 'remove' %}
-            {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" /></svg>' }}
-        {% elseif value == 'associate' %}
-            {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd" /></svg>' }}
-        {% elseif value == 'dissociate' %}
-            {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd" /></svg>' }}
-            {#        {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>' }}#}
-        {% endif %}
-    {% endapply %}
+    {%- if value == 'insert' -%}
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" /></svg>
+    {%- elseif value == 'update' -%}
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" /></svg>
+    {%- elseif value == 'remove' -%}
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M3 10a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd" /></svg>
+    {%- elseif value == 'associate' -%}
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd" /></svg>
+    {%- elseif value == 'dissociate' -%}
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M12.586 4.586a2 2 0 112.828 2.828l-3 3a2 2 0 01-2.828 0 1 1 0 00-1.414 1.414 4 4 0 005.656 0l3-3a4 4 0 00-5.656-5.656l-1.5 1.5a1 1 0 101.414 1.414l1.5-1.5zm-5 5a2 2 0 012.828 0 1 1 0 101.414-1.414 4 4 0 00-5.656 0l-3 3a4 4 0 105.656 5.656l1.5-1.5a1 1 0 10-1.414-1.414l-1.5 1.5a2 2 0 11-2.828-2.828l3-3z" clip-rule="evenodd" /></svg>
+        {#        {{ '<svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" viewBox="0 0 20 20" fill="currentColor"><path fill-rule="evenodd" d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" clip-rule="evenodd" /></svg>' }}#}
+    {%- endif -%}
 {% endmacro %}
 
 
 {% macro label_type(value) %}
-    {% apply spaceless %}
-        {% if value == 'insert' %}
-            {{ 'bg-green-400' }}
-        {% elseif value == 'update' %}
-            {{ 'bg-blue-400' }}
-        {% elseif value == 'remove' %}
-            {{ 'bg-red-400' }}
-            {#    {% elseif value in ['associate', 'dissociate'] %}#}
-        {% elseif value == 'associate' %}
-            {{ 'bg-yellow-400' }}
-        {% elseif value == 'dissociate' %}
-            {{ 'bg-red-300' }}
-        {% else %}
-            {{ 'bg-gray-400' }}
-        {% endif %}
-    {% endapply %}
+    {%- if value == 'insert' -%}
+        bg-green-400
+    {%- elseif value == 'update' -%}
+        bg-blue-400
+    {%- elseif value == 'remove' -%}
+        bg-red-400
+    {%- elseif value == 'associate' -%}
+        bg-yellow-400
+    {%- elseif value == 'dissociate' -%}
+        bg-red-300
+    {%- else -%}
+        bg-gray-400
+    {%- endif -%}
 {% endmacro %}


### PR DESCRIPTION
Hello,

This PR removes the call to the `spaceless` Twig filter that has been deprecated.

See https://twig.symfony.com/doc/3.x/filters/spaceless.html